### PR TITLE
Keep original full URI, add /executor

### DIFF
--- a/src/main/groovy/eu/spaziodati/azkaban/jobtype/ScriptHelper.groovy
+++ b/src/main/groovy/eu/spaziodati/azkaban/jobtype/ScriptHelper.groovy
@@ -57,7 +57,7 @@ public class ScriptHelper {
             log("Trying to execute flow '$flowid' of project '$projectName' ...")
 
             def uri = new URIBuilder(endpoint)
-                .setPath("/executor")
+                .setPath(uri.getPath() + "/executor")
                 .addParameter("session.id", sessionid)
                 .addParameter("ajax", "executeFlow")
                 .addParameter("project", projectName)


### PR DESCRIPTION
Fix the approach when Azkaban entry point isn't simply /, but sits behind a reverse proxy, and can be something like /azkaban_dev/ or /azkaban_prod/
