### PR TITLE
Added groovy.remote.{xms, xmx} parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -337,6 +337,8 @@ This job accepts also:
  - `groovy.remote.username` (*required*) the username
  - `groovy.remote.port` (*default*: `22`) the ssh connection port
  - `groovy.remote.password` the password, must be set if `groovy.remote.keyFile` is not set
+ - `groovy.remote.xms` set the minimum heap size for the remote jvm (if not set uses the azkaban settings)
+ - `groovy.remote.xmx` set the maximum heap size for the remote jvm (if not set uses the azkaban settings)
  - `groovy.remote.retry` (*default*: `5`) number of connection attempts. If connection cannot be established the plugin retries to connect to the host after 5 seconds (it may be useful in case of on-demand EC2 instances that are not immediately ready for ssh). After each attempt, the delay is doubled (so 5, 10, 20...)
  - `groovy.remote.keyFile` the path of file containing the ssh key, must be set if `groovy.remote.password` is not set
  - `groovy.remote.working.dir` the working directory on the remote machine, is created if not found.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>eu-spaziodati</groupId>
     <artifactId>azkaban-plugins-groovy</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.4</version>
+    <version>0.5.5</version>
     <description>A set of plugins for Azkaban workflow manager to run jobs as groovy scripts</description>
     <url>https://github.com/SpazioDati/azkaban-groovy-plugin</url>
     <properties>

--- a/src/main/groovy/eu/spaziodati/azkaban/jobtype/GroovyRemoteJob.groovy
+++ b/src/main/groovy/eu/spaziodati/azkaban/jobtype/GroovyRemoteJob.groovy
@@ -77,6 +77,9 @@ class GroovyRemoteJob extends GroovyProcessJob {
     static final INIT_SCRIPT = "groovy.remote.initScript"
     static final RETRY = "groovy.remote.retry"
 
+    static final XMS = "groovy.remote.xms"
+    static final XMX = "groovy.remote.xmx"
+
     static def DISCARD_LOG = ~/\d+ bytes transferred/
     static def FIRST_DELAY = 5
     static def random = new SecureRandom()
@@ -111,6 +114,25 @@ class GroovyRemoteJob extends GroovyProcessJob {
     String getNextRand() {
         new BigInteger(64, random).toString(32)
     }
+
+
+    @Override
+    String createCommandLine() {
+        def command = JAVA_COMMAND + " "
+        command += getJVMArguments() + " "
+
+        def xms = jobProps.getString(XMS) ?: getInitialMemorySize()
+        def xmx = jobProps.getString(XMX) ?: getMaxMemorySize()
+
+        command += "-Xms" + xms + " "
+        command += "-Xmx" + xmx + " "
+        command += "-cp " + createArguments(getClassPaths(), ":") + " "
+        command += getJavaClass() + " "
+        command += getMainArguments()
+
+        return command
+    }
+
 
     @Override
     void run() {

--- a/src/main/groovy/eu/spaziodati/azkaban/jobtype/GroovyRemoteJob.groovy
+++ b/src/main/groovy/eu/spaziodati/azkaban/jobtype/GroovyRemoteJob.groovy
@@ -121,8 +121,8 @@ class GroovyRemoteJob extends GroovyProcessJob {
         def command = JAVA_COMMAND + " "
         command += getJVMArguments() + " "
 
-        def xms = jobProps.getString(XMS) ?: getInitialMemorySize()
-        def xmx = jobProps.getString(XMX) ?: getMaxMemorySize()
+        def xms = jobProps.getString(XMS, getInitialMemorySize())
+        def xmx = jobProps.getString(XMX, getMaxMemorySize())
 
         command += "-Xms" + xms + " "
         command += "-Xmx" + xmx + " "


### PR DESCRIPTION
This change was made to get around the hard limit on `-Xmx` set by the azkaban-server.
With the new parameter it is now possible to specify different heap size params for the groovy remote jvm than the one running on the azkaban machine